### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "main.py"

--- a/README.md
+++ b/README.md
@@ -10,3 +10,5 @@ You can play the game online via [Repl.it](https://repl.it/@orrgorenn/TicTacToeP
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.
 
 Please make sure to update tests as appropriate.
+
+[![Run on Repl.it](https://repl.it/badge/github/orrgorenn/TicTacToePy)](https://repl.it/github/orrgorenn/TicTacToePy)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@orrgorenn/TicTacToePy-1).